### PR TITLE
[Feat] 현재 어색한 애니메이션 수정 (프로필 화면 중단 탭 연타시 색상 버그, 하단 탭바 첫 실행시 포커스 가운데서 부터 시작)

### DIFF
--- a/Whistle.xcodeproj/project.pbxproj
+++ b/Whistle.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		1B39555F2A9509A700BCB4DF /* SubmitButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B39555E2A9509A700BCB4DF /* SubmitButton.swift */; };
 		1BB7A06A2A9514B4002DD86F /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = 1BB7A0692A9514B4002DD86F /* .swiftlint.yml */; };
 		7801398A2AA127AE00D5FBDB /* SignInView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 780139892AA127AE00D5FBDB /* SignInView.swift */; };
+		782F1B252AA1C566006831C8 /* ProfileTabItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 782F1B242AA1C566006831C8 /* ProfileTabItem.swift */; };
 		786669472AA1282D00448EC7 /* AppleSignInViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 786669462AA1282D00448EC7 /* AppleSignInViewModel.swift */; };
 		786669492AA1284F00448EC7 /* UserAuth.swift in Sources */ = {isa = PBXBuildFile; fileRef = 786669482AA1284F00448EC7 /* UserAuth.swift */; };
 		7866694B2AA1287500448EC7 /* UserResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7866694A2AA1287500448EC7 /* UserResponse.swift */; };
@@ -61,6 +62,7 @@
 		1B39555E2A9509A700BCB4DF /* SubmitButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubmitButton.swift; sourceTree = "<group>"; };
 		1BB7A0692A9514B4002DD86F /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
 		780139892AA127AE00D5FBDB /* SignInView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignInView.swift; sourceTree = "<group>"; };
+		782F1B242AA1C566006831C8 /* ProfileTabItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileTabItem.swift; sourceTree = "<group>"; };
 		786669462AA1282D00448EC7 /* AppleSignInViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleSignInViewModel.swift; sourceTree = "<group>"; };
 		786669482AA1284F00448EC7 /* UserAuth.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserAuth.swift; sourceTree = "<group>"; };
 		7866694A2AA1287500448EC7 /* UserResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserResponse.swift; sourceTree = "<group>"; };
@@ -210,6 +212,7 @@
 				1B39555E2A9509A700BCB4DF /* SubmitButton.swift */,
 				78D148E82A9E13A800DDCE48 /* CustomBlurView.swift */,
 				78F980882A9F5B2500AD542A /* RoundedCorners.swift */,
+				782F1B242AA1C566006831C8 /* ProfileTabItem.swift */,
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -425,6 +428,7 @@
 				78F980892A9F5B2500AD542A /* RoundedCorners.swift in Sources */,
 				78DDADFA2AA1A37F00960552 /* AppKeys.swift in Sources */,
 				1B3955402A95069C00BCB4DF /* WhistleApp.swift in Sources */,
+				782F1B252AA1C566006831C8 /* ProfileTabItem.swift in Sources */,
 				78D148E02A9E0D1B00DDCE48 /* AppleSDGothic.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Whistle/UI/Components/ProfileTabItem.swift
+++ b/Whistle/UI/Components/ProfileTabItem.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct ProfileTabItem: ButtonStyle {
 
   // MARK: Lifecycle
+
   init(systemName: String, tab: String, selectedTab: Binding<ProfileView.profileTabCase>) {
     self.systemName = systemName
     self.tab = tab
@@ -17,6 +18,7 @@ struct ProfileTabItem: ButtonStyle {
   }
 
   // MARK: Internal
+
   let systemName: String
   let tab: String
   @Binding var selectedTab: ProfileView.profileTabCase
@@ -43,5 +45,6 @@ struct ProfileTabItem: ButtonStyle {
           .offset(y: 2.5)
       }
       .foregroundColor(tab == selectedTab.rawValue ? Color.White : Color.Gray30_Dark)
+      .background(.clear)
   }
 }

--- a/Whistle/UI/Components/ProfileTabItem.swift
+++ b/Whistle/UI/Components/ProfileTabItem.swift
@@ -1,0 +1,47 @@
+//
+//  ProfileTabItem.swift
+//  Whistle
+//
+//  Created by ChoiYujin on 9/1/23.
+//
+
+import SwiftUI
+
+struct ProfileTabItem: ButtonStyle {
+
+  // MARK: Lifecycle
+  init(systemName: String, tab: String, selectedTab: Binding<ProfileView.profileTabCase>) {
+    self.systemName = systemName
+    self.tab = tab
+    _selectedTab = selectedTab
+  }
+
+  // MARK: Internal
+  let systemName: String
+  let tab: String
+  @Binding var selectedTab: ProfileView.profileTabCase
+
+  func makeBody(configuration: Configuration) -> some View {
+    configuration.label
+      .frame(maxWidth: .infinity, maxHeight: .infinity)
+      .overlay {
+        Image(systemName: systemName)
+          .resizable()
+          .scaledToFit()
+          .frame(width: 24, height: 24)
+      }
+      .overlay(alignment: .bottom) {
+        Rectangle()
+          .foregroundColor(Color.Gray30_Dark)
+          .frame(height: 1)
+      }
+      .overlay(alignment: .bottom) {
+        Capsule()
+          .frame(width: (UIScreen.width - 32) / 2, height: 5)
+          .foregroundColor(.White)
+          .opacity(tab == selectedTab.rawValue ? 1 : 0)
+          .offset(y: 2.5)
+      }
+      .foregroundColor(tab == selectedTab.rawValue ? Color.White : Color.Gray30_Dark)
+  }
+}

--- a/Whistle/UI/Screens/Profile/GlassBottomSheet.swift
+++ b/Whistle/UI/Screens/Profile/GlassBottomSheet.swift
@@ -78,7 +78,7 @@ struct GlassBottomSheet: View {
     }
     .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottom)
     .ignoresSafeArea()
-    .animation(.easeInOut, value: isShowing)
+//    .animation(.easeInOut, value: isShowing)
   }
 }
 

--- a/Whistle/UI/Screens/Profile/ProfileView.swift
+++ b/Whistle/UI/Screens/Profile/ProfileView.swift
@@ -48,7 +48,9 @@ struct ProfileView: View {
           Button {
             tabSelection = .myVideo
           } label: {
-            Text("")
+            Color.gray
+              .opacity(0.01)
+              .frame(maxWidth: .infinity, maxHeight: .infinity)
           }
           .buttonStyle(ProfileTabItem(
             systemName: "square.grid.2x2.fill",
@@ -57,7 +59,9 @@ struct ProfileView: View {
           Button {
             tabSelection = .favoriteVideo
           } label: {
-            Text("")
+            Color.gray
+              .opacity(0.01)
+              .frame(maxWidth: .infinity, maxHeight: .infinity)
           }
           .buttonStyle(ProfileTabItem(
             systemName: "bookmark.fill",

--- a/Whistle/UI/Screens/Profile/ProfileView.swift
+++ b/Whistle/UI/Screens/Profile/ProfileView.swift
@@ -88,7 +88,6 @@ struct ProfileView: View {
       VStack {
         Spacer()
         GlassBottomSheet(isShowing: $isShowingBottomSheet, content: AnyView(Text("Hi")))
-          .animation(.easeIn(duration: 1.0), value: tabbarOpacity)
           .onChange(of: isShowingBottomSheet) { newValue in
             if !newValue {
               DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
@@ -101,7 +100,9 @@ struct ProfileView: View {
             DragGesture(minimumDistance: 20, coordinateSpace: .local)
               .onEnded { value in
                 if value.translation.height > 20 {
-                  isShowingBottomSheet = false
+                  withAnimation {
+                    isShowingBottomSheet = false
+                  }
                   DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
                     tabbarOpacity = 1
                   }
@@ -134,7 +135,9 @@ extension ProfileView {
         Spacer()
         Button {
           self.tabbarOpacity = 0
-          self.isShowingBottomSheet = true
+          withAnimation {
+            self.isShowingBottomSheet = true
+          }
         } label: {
           Circle()
             .foregroundColor(.Dim_Default)

--- a/Whistle/UI/Screens/Profile/ProfileView.swift
+++ b/Whistle/UI/Screens/Profile/ProfileView.swift
@@ -10,9 +10,20 @@ import SwiftUI
 // MARK: - ProfileView
 
 struct ProfileView: View {
+
+  // MARK: Public
+
+  public enum profileTabCase: String {
+    case myVideo
+    case favoriteVideo
+  }
+
+  // MARK: Internal
+
   let fontHeight = UIFont.preferredFont(forTextStyle: .title2).lineHeight
   @State var isShowingBottomSheet = false
   @State var tabbarDirection: CGFloat = -1.0
+  @State var tabSelection: profileTabCase = .myVideo
   @State var columns: [GridItem] = [
     GridItem(.flexible()),
     GridItem(.flexible()),
@@ -33,47 +44,28 @@ struct ProfileView: View {
         Spacer().frame(height: 64)
         glassView(width: UIScreen.width - 32)
           .padding(.bottom, 12)
-        HStack {
+        HStack(spacing: 0) {
           Button {
-            tabbarDirection = -1
+            tabSelection = .myVideo
           } label: {
-            VStack {
-              Spacer()
-              Image(systemName: "square.grid.2x2.fill")
-                .resizable()
-                .scaledToFit()
-                .frame(width: 24, height: 24)
-              Spacer()
-            }
-            .foregroundColor(tabbarDirection == -1 ? Color.White : Color.Gray30_Dark)
-            .frame(maxWidth: .infinity)
+            Text("")
           }
+          .buttonStyle(ProfileTabItem(
+            systemName: "square.grid.2x2.fill",
+            tab: profileTabCase.myVideo.rawValue,
+            selectedTab: $tabSelection))
           Button {
-            tabbarDirection = 1
+            tabSelection = .favoriteVideo
           } label: {
-            VStack {
-              Spacer()
-              Image(systemName: "bookmark.fill")
-                .resizable()
-                .scaledToFit()
-                .frame(width: 24, height: 24)
-              Spacer()
-            }
-            .foregroundColor(tabbarDirection == 1 ? Color.White : Color.Gray30_Dark)
-            .frame(maxWidth: .infinity)
+            Text("")
           }
+          .buttonStyle(ProfileTabItem(
+            systemName: "bookmark.fill",
+            tab: profileTabCase.favoriteVideo.rawValue,
+            selectedTab: $tabSelection))
         }
         .frame(height: 48)
-        Rectangle()
-          .foregroundColor(Color.Gray30_Dark)
-          .frame(height: 1)
-          .overlay {
-            Capsule()
-              .foregroundColor(Color.White)
-              .frame(width: (UIScreen.width - 32) / 2, height: 5)
-              .offset(x: tabbarDirection * (UIScreen.width - 32) / 4)
-          }
-          .padding(.bottom, 16)
+        .padding(.bottom, 16)
         ScrollView {
           LazyVGrid(columns: columns, spacing: 20) {
             ForEach(0 ..< 20) { _ in

--- a/Whistle/UI/Screens/TabbarView.swift
+++ b/Whistle/UI/Screens/TabbarView.swift
@@ -58,7 +58,6 @@ extension TabbarView {
       .foregroundColor(.Primary_Default)
       .frame(width: (UIScreen.width - 32) / 3 - 6)
       .offset(x: tabSelection.rawValue * ((UIScreen.width - 32) / 3))
-      .animation(.easeInOut)
       .padding(3)
       .overlay(
         RoundedRectangle(cornerRadius: 100)
@@ -67,14 +66,15 @@ extension TabbarView {
             lineWidth: 2)
           .frame(width: (UIScreen.width - 32) / 3 - 6)
           .offset(x: tabSelection.rawValue * ((UIScreen.width - 32) / 3))
-          .animation(.easeInOut)
           .padding(4))
       .foregroundColor(.clear)
       .frame(height: 56)
       .frame(maxWidth: .infinity)
       .overlay {
         Button {
-          self.tabSelection = .main
+          withAnimation {
+            self.tabSelection = .main
+          }
         } label: {
           Color.clear.overlay {
             Image(systemName: "house.fill")
@@ -89,7 +89,10 @@ extension TabbarView {
         .offset(x: -1 * ((UIScreen.width - 32) / 3))
 
         Button {
-          self.tabSelection = .upload
+          withAnimation {
+            self.tabSelection = .upload
+          }
+
         } label: {
           Color.clear.overlay {
             Image(systemName: "plus")
@@ -103,7 +106,9 @@ extension TabbarView {
         .foregroundColor(.white)
         .padding(3)
         Button {
-          self.tabSelection = .profile
+          withAnimation {
+            self.tabSelection = .profile
+          }
         } label: {
           Color.clear.overlay {
             Image(systemName: "person")


### PR DESCRIPTION
## 🎯 Related Issues

***
#### close #10

## ✅ What Did You Do
- [x] .animation -> withAnimation으로 수정
- [x] 하단 탭바 첫 실행시 포커스 가운데서 부터 시작하는 애니메이션 수정 -> 제대로 탭바 위치에 있도록
- [x] 프로필 화면 중단 탭 구현 방식 수정 (기존 -> ButtonStyle로 적용)
- [x] 프로필 화면 중단 탭 연타시 색상 버그 개선 
***

## 🎸 ETC

## 🛠️ FIXME

프로필 화면 중단 탭을 연타하면 하얀 사각형이 생깁니다.
기존 수정 전에는 플리커링 현상도 같이 나타났으나 수정 후 
인식되는 연타속도 개선 및 플리커링 현상이 사라졌습니다.