### PR TITLE
[Refactor] 메인화면 비디오가 전부 로드되기전에도 동작하도록 수정, 다른사람 프로필 버그 수정

### DIFF
--- a/Whistle/UI/Screens/Main/MainView.swift
+++ b/Whistle/UI/Screens/Main/MainView.swift
@@ -116,24 +116,25 @@ struct MainView: View {
     .background(.black)
     .task {
       await apiViewModel.requestMyProfile()
-
-      apiViewModel.requestContentList {
-        Task {
-          if !apiViewModel.contentList.isEmpty {
-            for _ in 0..<apiViewModel.contentList.count {
-              players.append(nil)
+      if apiViewModel.contentList.isEmpty {
+        apiViewModel.requestContentList {
+          Task {
+            if !apiViewModel.contentList.isEmpty {
+              for _ in 0..<apiViewModel.contentList.count {
+                players.append(nil)
+              }
+              log(players)
+              players[currentIndex] = AVPlayer(url: URL(string: apiViewModel.contentList[currentIndex].videoUrl ?? "")!)
+              playerIndex = currentIndex
+              guard let player = players[currentIndex] else {
+                return
+              }
+              currentVideoUserId = apiViewModel.contentList[currentIndex].userId ?? 0
+              currentVideoContentId = apiViewModel.contentList[currentIndex].contentId ?? 0
+              isCurrentVideoWhistled = apiViewModel.contentList[currentIndex].isWhistled
+              await player.seek(to: .zero)
+              player.play()
             }
-            log(players)
-            players[currentIndex] = AVPlayer(url: URL(string: apiViewModel.contentList[currentIndex].videoUrl ?? "")!)
-            playerIndex = currentIndex
-            guard let player = players[currentIndex] else {
-              return
-            }
-            currentVideoUserId = apiViewModel.contentList[currentIndex].userId ?? 0
-            currentVideoContentId = apiViewModel.contentList[currentIndex].contentId ?? 0
-            isCurrentVideoWhistled = apiViewModel.contentList[currentIndex].isWhistled
-            await player.seek(to: .zero)
-            player.play()
           }
         }
       }

--- a/Whistle/UI/Screens/Main/MainView.swift
+++ b/Whistle/UI/Screens/Main/MainView.swift
@@ -116,22 +116,26 @@ struct MainView: View {
     .background(.black)
     .task {
       await apiViewModel.requestMyProfile()
-      await apiViewModel.requestContentList()
-      if !apiViewModel.contentList.isEmpty {
-        for _ in 0..<apiViewModel.contentList.count {
-          players.append(nil)
+
+      apiViewModel.requestContentList {
+        Task {
+          if !apiViewModel.contentList.isEmpty {
+            for _ in 0..<apiViewModel.contentList.count {
+              players.append(nil)
+            }
+            log(players)
+            players[currentIndex] = AVPlayer(url: URL(string: apiViewModel.contentList[currentIndex].videoUrl ?? "")!)
+            playerIndex = currentIndex
+            guard let player = players[currentIndex] else {
+              return
+            }
+            currentVideoUserId = apiViewModel.contentList[currentIndex].userId ?? 0
+            currentVideoContentId = apiViewModel.contentList[currentIndex].contentId ?? 0
+            isCurrentVideoWhistled = apiViewModel.contentList[currentIndex].isWhistled
+            await player.seek(to: .zero)
+            player.play()
+          }
         }
-        log(players)
-        players[currentIndex] = AVPlayer(url: URL(string: apiViewModel.contentList[currentIndex].videoUrl ?? "")!)
-        playerIndex = currentIndex
-        guard let player = players[currentIndex] else {
-          return
-        }
-        currentVideoUserId = apiViewModel.contentList[currentIndex].userId ?? 0
-        currentVideoContentId = apiViewModel.contentList[currentIndex].contentId ?? 0
-        isCurrentVideoWhistled = apiViewModel.contentList[currentIndex].isWhistled
-        await player.seek(to: .zero)
-        player.play()
       }
     }
     .onChange(of: currentIndex) { newValue in

--- a/Whistle/UI/Screens/Main/MainView.swift
+++ b/Whistle/UI/Screens/Main/MainView.swift
@@ -197,7 +197,7 @@ struct MainView: View {
         log("Cancel")
       }
     }
-    .fullScreenCover(isPresented: $showUserProfile) {
+    .navigationDestination(isPresented: $showUserProfile) {
       UserProfileView(userId: currentVideoUserId)
         .environmentObject(apiViewModel)
         .environmentObject(tabbarModel)

--- a/Whistle/UI/Screens/Main/MainView.swift
+++ b/Whistle/UI/Screens/Main/MainView.swift
@@ -115,7 +115,9 @@ struct MainView: View {
     .navigationBarBackButtonHidden()
     .background(.black)
     .task {
-      await apiViewModel.requestMyProfile()
+      if apiViewModel.myProfile.userName.isEmpty {
+        await apiViewModel.requestMyProfile()
+      }
       if apiViewModel.contentList.isEmpty {
         apiViewModel.requestContentList {
           Task {

--- a/Whistle/UI/Screens/Profile/FollowView.swift
+++ b/Whistle/UI/Screens/Profile/FollowView.swift
@@ -18,10 +18,6 @@ enum profileTabStatus: String {
 
 // MARK: - FollowView
 
-private var selectedId: Int?
-
-// MARK: - FollowView
-
 struct FollowView: View {
 
   // MARK: Internal
@@ -93,11 +89,6 @@ struct FollowView: View {
     .task {
       await apiViewModel.requestMyFollow()
     }
-    .fullScreenCover(isPresented: $showUserProfile) {
-      UserProfileView(userId: selectedId ?? 0)
-        .environmentObject(apiViewModel)
-        .environmentObject(tabbarModel)
-    }
   }
 }
 
@@ -162,9 +153,11 @@ extension FollowView {
   @ViewBuilder
   func myFollowerList() -> some View {
     ForEach(apiViewModel.myFollow.followerList, id: \.userName) { follower in
-      Button {
-        selectedId = follower.followerId
-        showUserProfile = true
+      NavigationLink {
+        UserProfileView(userId: follower.followerId)
+          .environmentObject(apiViewModel)
+          .environmentObject(tabbarModel)
+          .id(UUID())
       } label: {
         personRow(
           isFollowed: Binding(get: {
@@ -177,15 +170,18 @@ extension FollowView {
           profileImage: follower.profileImg ?? "",
           userId: follower.followerId)
       }
+      .id(UUID())
     }
   }
 
   @ViewBuilder
   func myFollowingList() -> some View {
     ForEach(apiViewModel.myFollow.followingList, id: \.userName) { following in
-      Button {
-        selectedId = following.followingId
-        showUserProfile = true
+      NavigationLink {
+        UserProfileView(userId: following.followingId)
+          .environmentObject(apiViewModel)
+          .environmentObject(tabbarModel)
+          .id(UUID())
       } label: {
         personRow(
           isFollowed: .constant(true),
@@ -194,6 +190,7 @@ extension FollowView {
           profileImage: following.profileImg ?? "",
           userId: following.followingId)
       }
+      .id(UUID())
     }
   }
 }

--- a/Whistle/UI/Screens/Profile/MyContentListView.swift
+++ b/Whistle/UI/Screens/Profile/MyContentListView.swift
@@ -170,6 +170,8 @@ extension MyContentListView {
     VStack(spacing: 0) {
       HStack(spacing: 0) {
         Button {
+          players[currentIndex]?.pause()
+          players.removeAll()
           dismiss()
         } label: {
           Color.clear

--- a/Whistle/UI/Screens/Profile/ProfileView.swift
+++ b/Whistle/UI/Screens/Profile/ProfileView.swift
@@ -409,6 +409,7 @@ extension ProfileView {
       .fontSystem(fontDesignSystem: .body1_KO)
       .foregroundColor(.LabelColor_Primary_Dark)
     Button {
+      tabbarModel.tabSelectionNoAnimation = .upload
       withAnimation {
         tabbarModel.tabSelection = .upload
       }

--- a/Whistle/UI/Screens/Profile/UserContentListView.swift
+++ b/Whistle/UI/Screens/Profile/UserContentListView.swift
@@ -179,6 +179,8 @@ extension UserContentListView {
     VStack(spacing: 0) {
       HStack(spacing: 0) {
         Button {
+          players[currentIndex]?.pause()
+          players.removeAll()
           dismiss()
         } label: {
           Color.clear

--- a/Whistle/UI/Screens/Profile/UserFollowView.swift
+++ b/Whistle/UI/Screens/Profile/UserFollowView.swift
@@ -10,10 +10,6 @@ import SwiftUI
 
 // MARK: - UserFollowView
 
-private var selectedId: Int?
-
-// MARK: - UserFollowView
-
 struct UserFollowView: View {
 
   // MARK: Internal

--- a/Whistle/UI/Screens/Profile/UserFollowView.swift
+++ b/Whistle/UI/Screens/Profile/UserFollowView.swift
@@ -90,11 +90,6 @@ struct UserFollowView: View {
       userFollower = apiViewModel.userFollow.followerList
       userFollowing = apiViewModel.userFollow.followingList
     }
-    .fullScreenCover(isPresented: $showUserProfile) {
-      UserProfileView(userId: selectedId ?? 0)
-        .environmentObject(apiViewModel)
-        .environmentObject(tabbarModel)
-    }
   }
 }
 
@@ -159,9 +154,10 @@ extension UserFollowView {
   @ViewBuilder
   func userFollowerList() -> some View {
     ForEach(userFollower, id: \.userName) { follower in
-      Button {
-        selectedId = follower.followerId
-        showUserProfile = true
+      NavigationLink {
+        UserProfileView(userId: follower.followerId)
+          .environmentObject(apiViewModel)
+          .environmentObject(tabbarModel)
       } label: {
         personRow(
           isFollowed: Binding(get: {
@@ -180,9 +176,10 @@ extension UserFollowView {
   @ViewBuilder
   func userFollowingList() -> some View {
     ForEach(userFollowing, id: \.userName) { following in
-      Button {
-        selectedId = following.followingId
-        showUserProfile = true
+      NavigationLink {
+        UserProfileView(userId: following.followingId)
+          .environmentObject(apiViewModel)
+          .environmentObject(tabbarModel)
       } label: {
         personRow(
           isFollowed: Binding(get: {

--- a/Whistle/UI/Screens/Profile/UserProfileView.swift
+++ b/Whistle/UI/Screens/Profile/UserProfileView.swift
@@ -114,6 +114,7 @@ struct UserProfileView: View {
         isFollow = apiViewModel.userProfile.isFollowed == 1 ? true : false
       }
       .task {
+        log(userId)
         await apiViewModel.requestUserPostFeed(userId: userId)
       }
       .overlay {

--- a/Whistle/UI/Screens/TabbarView.swift
+++ b/Whistle/UI/Screens/TabbarView.swift
@@ -20,7 +20,6 @@ struct TabbarView: View {
   var body: some View {
     ZStack {
       NavigationStack {
-//        Color.Blue_Default
         MainView(mainOpacity: $mainOpacity)
           .environmentObject(apiViewModel)
           .environmentObject(tabbarModel)

--- a/Whistle/Utilities/Extensions/APIViewModel+PostFeed.swift
+++ b/Whistle/Utilities/Extensions/APIViewModel+PostFeed.swift
@@ -68,6 +68,7 @@ extension APIViewModel: PostFeedProtocol {
             }
           case .failure(let error):
             log("Error: \(error)")
+            self.userPostFeed = []
             continuation.resume()
           }
         }

--- a/Whistle/Utilities/Extensions/APIViewModel+PostFeed.swift
+++ b/Whistle/Utilities/Extensions/APIViewModel+PostFeed.swift
@@ -107,58 +107,53 @@ extension APIViewModel: PostFeedProtocol {
     }
   }
 
-  // FIXME: - 개수 Buffer 처럼 append 하도록 수정 필요하다고 생각함, 일단 기능 테스트 후에
-  func requestContentList() async {
-    await withCheckedContinuation { continuation in
-      AF.request(
-        "\(domainURL)/content/content-list",
-        method: .get,
-        headers: contentTypeJson)
-        .validate(statusCode: 200...300)
-        .response { response in
-          switch response.result {
-          case .success(let data):
-            do {
-              guard let data else {
-                return
-              }
-              let jsonArray = try JSONSerialization.jsonObject(with: data, options: []) as? [[String: Any]]
-
-              for jsonObject in jsonArray ?? [] {
-                let tempContent: MainContent = .init()
-                tempContent.contentId = jsonObject["content_id"] as? Int
-                tempContent.userId = jsonObject["user_id"] as? Int
-                tempContent.userName = jsonObject["user_name"] as? String
-                tempContent.profileImg = jsonObject["profile_img"] as? String
-                tempContent.caption = jsonObject["caption"] as? String
-                tempContent.videoUrl = jsonObject["video_url"] as? String
-                tempContent.thumbnailUrl = jsonObject["thumbnail_url"] as? String
-                tempContent.musicArtist = jsonObject["music_artist"] as? String
-                tempContent.musicTitle = jsonObject["music_title"] as? String
-                tempContent.musicTitle = jsonObject["music_title"] as? String
-                tempContent.hashtags = jsonObject["hashtags"] as? String
-                tempContent.hashtags = jsonObject["hashtags"] as? String
-                tempContent.whistleCount = jsonObject["content_whistle_count"] as? Int
-                tempContent.isWhistled = (jsonObject["is_whistled"] as? Int) == 0 ? false : true
-                tempContent.isFollowed = (jsonObject["is_followed"] as? Int) == 0 ? false : true
-                tempContent.isBookmarked = (jsonObject["is_bookmarked"] as? Int) == 0 ? false : true
-                if self.contentList.count < 2 {
-                  tempContent.player = AVPlayer(url: URL(string: tempContent.videoUrl ?? "")!)
-                }
-                self.contentList.append(tempContent)
-              }
-              continuation.resume()
-            } catch {
-              log("Error parsing JSON: \(error)")
-              log("피드를 불러올 수 없습니다.")
-              continuation.resume()
+  func requestContentList(completion: @escaping () -> ()) {
+    AF.request(
+      "\(domainURL)/content/content-list",
+      method: .get,
+      headers: contentTypeJson)
+      .validate(statusCode: 200...300)
+      .response { response in
+        switch response.result {
+        case .success(let data):
+          do {
+            guard let data else {
+              return
             }
-          case .failure(let error):
-            log("Error: \(error)")
-            continuation.resume()
+            let jsonArray = try JSONSerialization.jsonObject(with: data, options: []) as? [[String: Any]]
+
+            for jsonObject in jsonArray ?? [] {
+              let tempContent: MainContent = .init()
+              tempContent.contentId = jsonObject["content_id"] as? Int
+              tempContent.userId = jsonObject["user_id"] as? Int
+              tempContent.userName = jsonObject["user_name"] as? String
+              tempContent.profileImg = jsonObject["profile_img"] as? String
+              tempContent.caption = jsonObject["caption"] as? String
+              tempContent.videoUrl = jsonObject["video_url"] as? String
+              tempContent.thumbnailUrl = jsonObject["thumbnail_url"] as? String
+              tempContent.musicArtist = jsonObject["music_artist"] as? String
+              tempContent.musicTitle = jsonObject["music_title"] as? String
+              tempContent.musicTitle = jsonObject["music_title"] as? String
+              tempContent.hashtags = jsonObject["hashtags"] as? String
+              tempContent.hashtags = jsonObject["hashtags"] as? String
+              tempContent.whistleCount = jsonObject["content_whistle_count"] as? Int
+              tempContent.isWhistled = (jsonObject["is_whistled"] as? Int) == 0 ? false : true
+              tempContent.isFollowed = (jsonObject["is_followed"] as? Int) == 0 ? false : true
+              tempContent.isBookmarked = (jsonObject["is_bookmarked"] as? Int) == 0 ? false : true
+              if self.contentList.count < 2 {
+                tempContent.player = AVPlayer(url: URL(string: tempContent.videoUrl ?? "")!)
+              }
+              self.contentList.append(tempContent)
+            }
+            completion()
+          } catch {
+            log("Error parsing JSON: \(error)")
+            log("피드를 불러올 수 없습니다.")
           }
+        case .failure(let error):
+          log("Error: \(error)")
         }
-    }
+      }
   }
 
   // /user/post/suspend-list

--- a/Whistle/ViewModels/Protocols/PostFeedProtocol.swift
+++ b/Whistle/ViewModels/Protocols/PostFeedProtocol.swift
@@ -13,7 +13,7 @@ protocol PostFeedProtocol {
   func requestMyPostFeed() async
   func requestUserPostFeed(userId: Int) async
   func requestMyBookmark() async
-  func requestContentList() async
+  func requestContentList(completion: @escaping () -> ())
   func requestReportedConent() async
   func postFeedPlayerChanged()
   func actionBookmark(contentId: Int) async -> Bool

--- a/Whistle/WhistleApp.swift
+++ b/Whistle/WhistleApp.swift
@@ -38,17 +38,17 @@ struct WhistleApp: App {
   var body: some Scene {
     WindowGroup {
       if isAccess {
-        NavigationStack {
-          PickerConfigViewControllerWrapper(options: $pickerOptions)
-        }
-//        TabbarView()
-//          .environmentObject(apiViewModel)
-//          .environmentObject(userAuth)
-//          .task {
-//            if isAccess {
-//              appleSignInViewModel.userAuth.loadData { }
-//            }
-//          }
+//        NavigationStack {
+//          PickerConfigViewControllerWrapper(options: $pickerOptions)
+//        }
+        TabbarView()
+          .environmentObject(apiViewModel)
+          .environmentObject(userAuth)
+          .task {
+            if isAccess {
+              appleSignInViewModel.userAuth.loadData { }
+            }
+          }
       } else {
         NavigationStack {
           SignInView()


### PR DESCRIPTION
## What is this PR?
- PR에 대한 설명

- [x] 메인화면 비디오가 전부 로드되기전에도 동작하도록 수정
- [x] 다른 사람 프로필 비디오 로드가 비정상적인 것 수정
- [x] 팔로워 뷰 이동시 팔로워 목록이 제대로 저장되도록 수정  
- [x] 프로필 컨텐츠 리스트 뒤로가기 시 플레이어가 멈추지 않는 버그 수정 

close #82

## PR Type
- [x] Bugfix
- [ ] Chore
- [ ] New feature (기능을 추가하는 feat)
- [ ] Breaking change (기존의 기능이 동작하지 않을 수 있는 fix/feat)
- [ ] Documentation Update

## ScreenShot(if available)
|기능|스크린샷|
|:--:|:--:|
|GIF|<img src = "" width ="250">|

## Further comments
