### PR TITLE
[FEAT] #136 - 촬영한 비디오 가공하기

### DIFF
--- a/Whistle.xcodeproj/project.pbxproj
+++ b/Whistle.xcodeproj/project.pbxproj
@@ -315,6 +315,7 @@
 		1BE8EA052AAE4D8B00EB0A55 /* Music.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BE8EA042AAE4D8B00EB0A55 /* Music.swift */; };
 		1BE8EA082AAE595000EB0A55 /* MusicListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BE8EA072AAE595000EB0A55 /* MusicListView.swift */; };
 		1BE8EA122AB0F7E800EB0A55 /* CircularProgressBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BE8EA112AB0F7E800EB0A55 /* CircularProgressBar.swift */; };
+		1BED4F562ADAE81D00A96C58 /* Aespa in Frameworks */ = {isa = PBXBuildFile; productRef = 1BED4F552ADAE81D00A96C58 /* Aespa */; };
 		780039082AD7E0020033B9F1 /* VersionCheck.swift in Sources */ = {isa = PBXBuildFile; fileRef = 780039072AD7E0020033B9F1 /* VersionCheck.swift */; };
 		7801398A2AA127AE00D5FBDB /* SignInView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 780139892AA127AE00D5FBDB /* SignInView.swift */; };
 		7819532E2ABA261A0053B975 /* MyContentListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7819532D2ABA261A0053B975 /* MyContentListView.swift */; };
@@ -379,7 +380,6 @@
 		788E68692AD6B6710056C18B /* VideoSettingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 788E68612AD6B6710056C18B /* VideoSettingView.swift */; };
 		788E686A2AD6B6710056C18B /* VideoConentViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 788E68622AD6B6710056C18B /* VideoConentViewModel.swift */; };
 		788E686B2AD6B6710056C18B /* PhotoFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 788E68632AD6B6710056C18B /* PhotoFile.swift */; };
-		788E686E2AD6B6A60056C18B /* Aespa in Frameworks */ = {isa = PBXBuildFile; productRef = 788E686D2AD6B6A60056C18B /* Aespa */; };
 		788E68702AD6C9DB0056C18B /* AccessView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 788E686F2AD6C9DB0056C18B /* AccessView.swift */; };
 		788F43F02AA5CD9F00718D38 /* MainView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 788F43EF2AA5CD9F00718D38 /* MainView.swift */; };
 		788F43F72AA6136F00718D38 /* Player.swift in Sources */ = {isa = PBXBuildFile; fileRef = 788F43F62AA6136F00718D38 /* Player.swift */; };
@@ -764,6 +764,7 @@
 		1BE8EA042AAE4D8B00EB0A55 /* Music.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Music.swift; sourceTree = "<group>"; };
 		1BE8EA072AAE595000EB0A55 /* MusicListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MusicListView.swift; sourceTree = "<group>"; };
 		1BE8EA112AB0F7E800EB0A55 /* CircularProgressBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CircularProgressBar.swift; sourceTree = "<group>"; };
+		1BED4F542ADAE7F200A96C58 /* Aespa */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = Aespa; path = ../../Downloads/Aespa; sourceTree = "<group>"; };
 		780039072AD7E0020033B9F1 /* VersionCheck.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VersionCheck.swift; sourceTree = "<group>"; };
 		780139892AA127AE00D5FBDB /* SignInView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignInView.swift; sourceTree = "<group>"; };
 		7819532D2ABA261A0053B975 /* MyContentListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyContentListView.swift; sourceTree = "<group>"; };
@@ -880,7 +881,7 @@
 				78A58E062AD1C287007F6A69 /* ReverseMask in Frameworks */,
 				1BD4E5B92ABA2F5600ADB783 /* VideoPicker.framework in Frameworks */,
 				78F780052AB34876005623CD /* GoogleSignIn in Frameworks */,
-				788E686E2AD6B6A60056C18B /* Aespa in Frameworks */,
+				1BED4F562ADAE81D00A96C58 /* Aespa in Frameworks */,
 				1BD4E56B2ABA275200ADB783 /* SnapKit in Frameworks */,
 				78E1755E2ABA838200731259 /* MarkdownUI in Frameworks */,
 				78E738CA2AA9A90F00480046 /* Kingfisher in Frameworks */,
@@ -1974,6 +1975,7 @@
 		1BD4E7BF2ABA31B600ADB783 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				1BED4F542ADAE7F200A96C58 /* Aespa */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -2222,7 +2224,7 @@
 				1BD4E56A2ABA275200ADB783 /* SnapKit */,
 				78E1755D2ABA838200731259 /* MarkdownUI */,
 				78A58E052AD1C287007F6A69 /* ReverseMask */,
-				788E686D2AD6B6A60056C18B /* Aespa */,
+				1BED4F552ADAE81D00A96C58 /* Aespa */,
 			);
 			productName = Whistle;
 			productReference = 1B39553C2A95069C00BCB4DF /* Whistle.app */;
@@ -2288,7 +2290,6 @@
 				1BD4E5692ABA275200ADB783 /* XCRemoteSwiftPackageReference "SnapKit" */,
 				78E1755C2ABA838200731259 /* XCRemoteSwiftPackageReference "swift-markdown-ui" */,
 				78A58E042AD1C287007F6A69 /* XCRemoteSwiftPackageReference "ReverseMask" */,
-				788E686C2AD6B6A60056C18B /* XCRemoteSwiftPackageReference "Aespa" */,
 			);
 			productRefGroup = 1B39553D2A95069C00BCB4DF /* Products */;
 			projectDirPath = "";
@@ -3144,14 +3145,6 @@
 				minimumVersion = 5.0.1;
 			};
 		};
-		788E686C2AD6B6A60056C18B /* XCRemoteSwiftPackageReference "Aespa" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/enebin/Aespa.git";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 0.3.1;
-			};
-		};
 		78A58E042AD1C287007F6A69 /* XCRemoteSwiftPackageReference "ReverseMask" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/stateman92/ReverseMask.git";
@@ -3207,6 +3200,10 @@
 			package = 1BD4E5692ABA275200ADB783 /* XCRemoteSwiftPackageReference "SnapKit" */;
 			productName = SnapKit;
 		};
+		1BED4F552ADAE81D00A96C58 /* Aespa */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = Aespa;
+		};
 		7866694D2AA1289900448EC7 /* Alamofire */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 7866694C2AA1289900448EC7 /* XCRemoteSwiftPackageReference "Alamofire" */;
@@ -3221,11 +3218,6 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 787AF5632AA85D2C00C190E6 /* XCRemoteSwiftPackageReference "SwiftyJSON" */;
 			productName = SwiftyJSON;
-		};
-		788E686D2AD6B6A60056C18B /* Aespa */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 788E686C2AD6B6A60056C18B /* XCRemoteSwiftPackageReference "Aespa" */;
-			productName = Aespa;
 		};
 		78A58E052AD1C287007F6A69 /* ReverseMask */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Whistle.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Whistle.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,15 +1,6 @@
 {
   "pins" : [
     {
-      "identity" : "aespa",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/enebin/Aespa.git",
-      "state" : {
-        "revision" : "ff1421990022b80de5eb98a9326c3138a459a405",
-        "version" : "0.3.1"
-      }
-    },
-    {
       "identity" : "alamofire",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Alamofire/Alamofire.git",

--- a/Whistle/Models/VideoEditor/EditableVideo.swift
+++ b/Whistle/Models/VideoEditor/EditableVideo.swift
@@ -50,7 +50,7 @@ struct EditableVideo: Identifiable {
     self.rotation = rotation
   }
 
-  mutating func updateThumbnails(_: GeometryProxy) {
+  mutating func updateThumbnails() {
 //    let imagesCount = thumbnailCount(geo)
     let imagesCount = 21
 

--- a/Whistle/UI/Screens/VideoEditor/EditorView/PlayerHolderView.swift
+++ b/Whistle/UI/Screens/VideoEditor/EditorView/PlayerHolderView.swift
@@ -10,7 +10,6 @@ import SwiftUI
 // MARK: - PlayerHolderView
 
 struct PlayerHolderView: View {
-  @Binding var isFullScreen: Bool
   @ObservedObject var editorVM: EditorViewModel
   @ObservedObject var videoPlayer: VideoPlayerManager
   @ObservedObject var musicVM: MusicViewModel
@@ -126,7 +125,6 @@ extension PlayerHolderView {
 // MARK: - PlayerControl
 
 struct PlayerControl: View {
-  @Binding var isFullScreen: Bool
   @ObservedObject var editorVM: EditorViewModel
   @ObservedObject var videoPlayer: VideoPlayerManager
   var body: some View {

--- a/Whistle/UI/Screens/VideoView/VideoConentViewModel.swift
+++ b/Whistle/UI/Screens/VideoView/VideoConentViewModel.swift
@@ -5,11 +5,11 @@
 //  Created by ChoiYujin on 10/11/23.
 //
 
+import Aespa
+import AVFoundation
 import Combine
 import Foundation
 import SwiftUI
-
-import Aespa
 
 // MARK: - VideoContentViewModel
 
@@ -22,9 +22,6 @@ class VideoContentViewModel: ObservableObject {
 
   private var subscription = Set<AnyCancellable>()
 
-  @Published var videoAlbumCover: Image?
-  @Published var photoAlbumCover: Image?
-
   @Published var videoFiles: [VideoAssetModel] = []
   @Published var photoFiles: [PhotoAssetModel] = []
 
@@ -34,7 +31,7 @@ class VideoContentViewModel: ObservableObject {
 
     // Common setting
     aespaSession
-      .focus(mode: .locked)
+      .focus(mode: .continuousAutoFocus)
       .changeMonitoring(enabled: true)
       .orientation(to: .portrait)
       .quality(to: .high)
@@ -43,33 +40,10 @@ class VideoContentViewModel: ObservableObject {
           print("Error: ", error)
         }
       }
+      .unmute()
 
     aespaSession
       .stabilization(mode: .auto)
-
-    aespaSession.videoFilePublisher
-      .receive(on: DispatchQueue.main)
-      .map { result -> Image? in
-        if case .success(let file) = result {
-          return file.thumbnailImage
-        } else {
-          return nil
-        }
-      }
-      .assign(to: \.videoAlbumCover, on: self)
-      .store(in: &subscription)
-
-    aespaSession.photoFilePublisher
-      .receive(on: DispatchQueue.main)
-      .map { result -> Image? in
-        if case .success(let file) = result {
-          return file.thumbnailImage
-        } else {
-          return nil
-        }
-      }
-      .assign(to: \.photoAlbumCover, on: self)
-      .store(in: &subscription)
   }
 }
 

--- a/Whistle/Utilities/Extensions/Extension+AVAssets.swift
+++ b/Whistle/Utilities/Extensions/Extension+AVAssets.swift
@@ -23,19 +23,7 @@ extension AVAsset {
   func getImage(_ second: Int, compressionQuality: Double = 0.05) -> UIImage? {
     let imgGenerator = AVAssetImageGenerator(asset: self)
     imgGenerator.appliesPreferredTrackTransform = true
-//    imgGenerator.requestedTimeToleranceBefore = CMTime.zero
-//    imgGenerator.requestedTimeToleranceAfter = CMTime.zero
 
-//    let time = CMTimeMake(value: Int64(second), timescale: 1)
-//    do {
-//      let cgImage = try imgGenerator.copyCGImage(at: time, actualTime: nil)
-//      let uiImage = UIImage(cgImage: cgImage)
-//      return uiImage
-//      // 이제 고화질 썸네일을 uiImage에 가지고 있습니다.
-//    } catch {
-//      print("썸네일 생성 오류: \(error)")
-//    }
-//    return nil
     guard
       let cgImage = try? imgGenerator.copyCGImage(
         at: .init(

--- a/Whistle/ViewModels/VideoEditor/EditorViewModel.swift
+++ b/Whistle/ViewModels/VideoEditor/EditorViewModel.swift
@@ -21,9 +21,9 @@ class EditorViewModel: ObservableObject {
 
   private var projectEntity: ProjectEntity?
 
-  func setNewVideo(_ url: URL, geo: GeometryProxy) {
+  func setNewVideo(_ url: URL) {
     currentVideo = .init(url: url)
-    currentVideo?.updateThumbnails(geo)
+    currentVideo?.updateThumbnails()
     currentVideo?.generateHQThumbnails()
     createProject()
   }
@@ -45,7 +45,7 @@ class EditorViewModel: ObservableObject {
     return UIImage()
   }
 
-  func setProject(_ project: ProjectEntity, geo: GeometryProxy) {
+  func setProject(_ project: ProjectEntity) {
     projectEntity = project
 
     guard let url = project.videoURL else { return }
@@ -64,7 +64,7 @@ class EditorViewModel: ObservableObject {
     let frame = VideoFrames(scaleValue: project.frameScale, frameColor: project.wrappedColor)
     currentVideo?.videoFrames = frame
     frames = frame
-    currentVideo?.updateThumbnails(geo)
+    currentVideo?.updateThumbnails()
     if let audio = project.audio?.audioModel {
       currentVideo?.audio = audio
     }


### PR DESCRIPTION
## What is this PR?
- 촬영한 비디오를 저장하지 않고 그대로 가져와 가공할 수 있도록 했습니다.
- 기존에 패키지로 사용했던 Aespa를 프레임워크로 가져와 수정했습니다.
- 갤러리를 표시하는 버튼에 들어갈 이미지를 앨범 첫 번째 비디오의 썸네일로 대체했습니다.
- VideoContentView의 변수의 순서를 정리하고 주석을 달아 보기 좋도록 수정했습니다.
- MainEditor에서 전달하는 필요없는 geometry 정보를 삭제함과 더불어 관련 함수를 수정했습니다.


## PR Type
- [ ] Bugfix
- [ ] Chore
- [ ] New feature (기능을 추가하는 feat)
- [X] Breaking change (기존의 기능이 동작하지 않을 수 있는 fix/feat)
- [ ] Documentation Update

## Further comments
- VideoContentView를 크게 수정해 conflict가 많이 날 수도 있습니다... 저를 찾아주세요