### PR TITLE
[#293] PhotoFile/VideoFile alias 빌드 오류 복구

### DIFF
--- a/Aespa/Data/File/PhotoFile.swift
+++ b/Aespa/Data/File/PhotoFile.swift
@@ -1,10 +1,3 @@
-//
-//  PhotoFile.swift
-//
-//
-//  Created by 이영빈 on 2023/06/18.
-//
-
 import Foundation
 import SwiftUI
 import UIKit
@@ -21,6 +14,11 @@ public struct PhotoFile {
 
   /// The captured image of type `UIImage`.
   public var image: UIImage
+
+  public init(creationDate: Date, image: UIImage) {
+    self.creationDate = creationDate
+    self.image = image
+  }
 }
 
 // MARK: Comparable
@@ -36,4 +34,12 @@ extension PhotoFile {
   public var thumbnailImage: Image {
     Image(uiImage: image)
   }
+}
+
+// MARK: - AespaFileTypes
+
+/// Namespace used by downstream modules to reference Aespa file models.
+public enum AespaFileTypes {
+  public typealias Photo = PhotoFile
+  public typealias Video = VideoFile
 }

--- a/Aespa/Data/File/VideoFile.swift
+++ b/Aespa/Data/File/VideoFile.swift
@@ -1,10 +1,4 @@
-//
-//  VideoFile.swift
-//
-//
-//  Created by 이영빈 on 2023/06/13.
-//
-
+import Foundation
 import SwiftUI
 import UIKit
 
@@ -27,6 +21,12 @@ public struct VideoFile {
 
   /// A thumbnail image, of type `UIImage`, generated from the video.
   public var thumbnail: UIImage
+
+  public init(creationDate: Date, path: URL?, thumbnail: UIImage) {
+    self.creationDate = creationDate
+    self.path = path
+    self.thumbnail = thumbnail
+  }
 }
 
 // MARK: Comparable

--- a/Whistle/Models/Photo/PhotoFile.swift
+++ b/Whistle/Models/Photo/PhotoFile.swift
@@ -1,39 +1,4 @@
-//
-//  PhotoFile.swift
-//
-//
-//  Created by 이영빈 on 2023/06/18.
-//
+import Aespa
 
-import Foundation
-import SwiftUI
-import UIKit
-
-// MARK: - PhotoFile
-
-/// `PhotoFile` struct models a photo file along with its related metadata.
-///
-/// The struct represents different details about a photo file, such as its creation date and the image itself.
-/// To get more meta data from the image, you should refer to `PhotoAsset`
-public struct PhotoFile {
-  /// A `Date` value indicating the moment the photo was taken.
-  public let creationDate: Date
-
-  /// The captured image of type `UIImage`.
-  public var image: UIImage
-}
-
-// MARK: Comparable
-
-extension PhotoFile: Comparable {
-  public static func < (lhs: PhotoFile, rhs: PhotoFile) -> Bool {
-    lhs.creationDate > rhs.creationDate
-  }
-}
-
-extension PhotoFile {
-  /// The captured image presented as a SwiftUI `Image`.
-  public var thumbnailImage: Image {
-    Image(uiImage: image)
-  }
-}
+/// Use the shared Aespa model instead of duplicating the same type in Whistle.
+public typealias PhotoFile = AespaFileTypes.Photo

--- a/Whistle/Models/Photo/VideoFile.swift
+++ b/Whistle/Models/Photo/VideoFile.swift
@@ -1,45 +1,4 @@
-//
-//  VideoFile.swift
-//
-//
-//  Created by 이영빈 on 2023/06/13.
-//
+import Aespa
 
-import SwiftUI
-import UIKit
-
-// MARK: - VideoFile
-
-/// `VideoFile` represents a video file along with its related metadata.
-///
-/// This struct encapsulates various information about a video file, such as the file's path (`path`)
-/// and a thumbnail image (`thumbnail`) derived from the video content.
-///
-/// - Warning: The path is temporary and will be removed once the application terminates.
-public struct VideoFile {
-  /// A `Date` value representing when the video file was created.
-  public let creationDate: Date
-
-  /// The temporary path of the recorded video file.
-  ///
-  /// - Warning: This path is temporary and will be removed when the application terminates.
-  public let path: URL?
-
-  /// A thumbnail image, of type `UIImage`, generated from the video.
-  public var thumbnail: UIImage
-}
-
-// MARK: Comparable
-
-extension VideoFile: Comparable {
-  public static func < (lhs: VideoFile, rhs: VideoFile) -> Bool {
-    lhs.creationDate > rhs.creationDate
-  }
-}
-
-extension VideoFile {
-  /// A thumbnail image, of type SwiftUI `Image`, generated from the video.
-  public var thumbnailImage: Image {
-    Image(uiImage: thumbnail)
-  }
-}
+/// Use the shared Aespa model instead of duplicating the same type in Whistle.
+public typealias VideoFile = AespaFileTypes.Video


### PR DESCRIPTION
## 변경 요약
- AespaFileTypes 네임스페이스 도입
- Whistle PhotoFile/VideoFile alias를 AespaFileTypes로 연결
- Aespa PhotoFile/VideoFile public initializer 추가

## 검증
- xcodebuild -project Whistle.xcodeproj -scheme Whistle -configuration Debug -destination 'generic/platform=iOS' build CODE_SIGNING_ALLOWED=NO (성공)

Closes #305